### PR TITLE
Change enables on AT2L0 for prebeam motion checkout

### DIFF
--- a/plc-lfe-motion/lfe_motion/POUs/PRG_AT2L0_SOLID.TcPOU
+++ b/plc-lfe-motion/lfe_motion/POUs/PRG_AT2L0_SOLID.TcPOU
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.2">
   <POU Name="PRG_AT2L0_SOLID" Id="{6180f524-6468-4c61-b137-11e8cfa13685}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_AT2L0_SOLID
 VAR
 	bAT2L0_debug: BOOL := FALSE;
 	nAT2L0_enableMode: ENUM_StageEnableMode := ENUM_StageEnableMode.DURING_MOTION;
-	bAT2L0_HWEnable: BOOL := FALSE;
 	
 	iIndex: INT;
 	fbAT2L0_motion: ARRAY [0..18] OF FB_MotionStage;
@@ -132,16 +131,15 @@ fbAT2L0_axes[18]:= ADR(Main.M19);
 
 IF bAT2L0_debug = TRUE THEN
 	nAT2L0_enableMode := ENUM_StageEnableMode.ALWAYS;
-	bAT2L0_HWEnable := TRUE;
 ELSE
 	nAT2L0_enableMode := ENUM_StageEnableMode.DURING_MOTION;
-	bAT2L0_HWEnable := FALSE;
 END_IF
 
 FOR iIndex := 0 TO 18 BY 1 DO
 	fbAT2L0_motion[iIndex](stMotionStage := fbAT2L0_axes[iIndex]^);
 	fbAT2L0_axes[iIndex]^.nEnableMode := nAT2L0_enableMode;
-	fbAT2L0_axes[iIndex]^.bHardwareEnable := bAT2L0_HWEnable;
+    fbAT2L0_axes[iIndex]^.bHardwareEnable := TRUE;
+	fbAT2L0_axes[iIndex]^.bPowerSelf := TRUE;
 END_FOR
 iIndex := 0;
 
@@ -206,5 +204,13 @@ nM19CoilA := UINT_TO_INT(nM19CoilARaw);
 nM19CoilB := UINT_TO_INT(nM19CoilBRaw);
 //nM19Current := ABS(nM2CoilA) + ABS(nM2CoilB);]]></ST>
     </Implementation>
+    <LineIds Name="PRG_AT2L0_SOLID">
+      <LineId Id="3" Count="21" />
+      <LineId Id="26" Count="1" />
+      <LineId Id="29" Count="4" />
+      <LineId Id="205" Count="0" />
+      <LineId Id="34" Count="62" />
+      <LineId Id="2" Count="0" />
+    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
Changes to AT2L0 POU:
Setting axis enables to allow EPICS motion control for prebeam checkout. 