### PR TITLE
FIX: include VAR/END_VAR tags

### DIFF
--- a/plc-lfe-motion/_Config/PLC/lfe_motion.xti
+++ b/plc-lfe-motion/_Config/PLC/lfe_motion.xti
@@ -967,6 +967,20 @@ External Setpoint Generation:
 					<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
 				</Var>
 				<Var>
+					<Name>PRG_AT2L0_SOLID.nM1CoilARaw</Name>
+					<Comment>
+						<![CDATA[ For plotting voltage/current during debugging]]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
+					<Name>PRG_AT2L0_SOLID.nM1CoilBRaw</Name>
+					<Comment>
+						<![CDATA[ ..CoilBRaw is currently linked to EL7041 'Coil Voltage A']]>
+					</Comment>
+					<Type>UINT</Type>
+				</Var>
+				<Var>
 					<Name>PRG_AT2L0_SOLID.fbAT2L0_motion[0].fbDriveVirtual.MasterAxis.NcToPlc</Name>
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 					<SubVar>
@@ -1896,20 +1910,6 @@ External Setpoint Generation:
 ]]>
 						</Comment>
 					</SubVar>
-				</Var>
-				<Var>
-					<Name>PRG_AT2L0_SOLID.nM1CoilARaw</Name>
-					<Comment>
-						<![CDATA[ For plotting voltage/current during debugging]]>
-					</Comment>
-					<Type>UINT</Type>
-				</Var>
-				<Var>
-					<Name>PRG_AT2L0_SOLID.nM1CoilBRaw</Name>
-					<Comment>
-						<![CDATA[ ..CoilBRaw is currently linked to EL7041 'Coil Voltage A']]>
-					</Comment>
-					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>PRG_AT2L0_SOLID.nM2CoilARaw</Name>

--- a/plc-lfe-motion/lfe_motion/POUs/PRG_1_PlcTask.TcPOU
+++ b/plc-lfe-motion/lfe_motion/POUs/PRG_1_PlcTask.TcPOU
@@ -7,9 +7,9 @@
     Only "fast" programs are allowed here,
     anything else needs to be relegated to a second task
 *)
-
-fbLogHandler : FB_LogHandler;
-]]></Declaration>
+VAR
+    fbLogHandler : FB_LogHandler;
+END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[
 PRG_2_PMPS_PRE();


### PR DESCRIPTION
#34 broke the build because it did not have VAR/END_VAR tags around the variable declaration. Not sure if this is something we want to lint for or if we need to be more diligent about reviewing PRs.