### PR TITLE
FIX: Imager positions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@ TrialLicense.tclrs
 *.tmcRefac
 .pytmc_build
 
+# An extra
+UpgradeLog.htm
+
 # Vim ignores
 *.swp

--- a/plc-lfe-motion/_Config/NC/Axes/IM1L1-PPM-MMS.xti
+++ b/plc-lfe-motion/_Config/NC/Axes/IM1L1-PPM-MMS.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.22" ClassName="CNcAxisDef" SubType="1">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -1329,19 +1329,21 @@ External Setpoint Generation:
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
-			<EncPara ScaleFactorNumerator="5e-05" Offset="-214675.2262" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-89.3751"/>
-				<SoftEndMaxControl Enable="true"/>
+			<EncPara ScaleFactorNumerator="5e-05" Offset="-214686.941" MaxCount="#xffffffff" ReferenceSystem="1">
+				<SoftEndMinControl Enable="true" Range="-101.12"/>
+				<SoftEndMaxControl Enable="true" Range="-11"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
-				<ParameterChanged>25</ParameterChanged>
-				<ParameterChanged>7</ParameterChanged>
+				<ParameterChanged>14</ParameterChanged>
+				<ParameterChanged>11</ParameterChanged>
+				<ParameterChanged>13</ParameterChanged>
+				<ParameterChanged>12</ParameterChanged>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>37632</BitOffs>
+					<BitOffs>43712</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
 						<Comment>
@@ -1371,7 +1373,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>61184</BitOffs>
+					<BitOffs>67264</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1385,7 +1387,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>38272</BitOffs>
+					<BitOffs>44352</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
@@ -1423,7 +1425,7 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>61824</BitOffs>
+					<BitOffs>67904</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1477,7 +1479,7 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>FromPlc</Name>
 				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>36608</BitOffs>
+				<BitOffs>42688</BitOffs>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
@@ -1485,7 +1487,7 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>ToPlc</Name>
 				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>59136</BitOffs>
+				<BitOffs>65216</BitOffs>
 				<SubVar>
 					<Name>AxisState</Name>
 					<Comment>

--- a/plc-lfe-motion/_Config/NC/Axes/IM3L0-PPM-MMS.xti
+++ b/plc-lfe-motion/_Config/NC/Axes/IM3L0-PPM-MMS.xti
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.22" ClassName="CNcAxisDef" SubType="1">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNcAxisDef" SubType="1">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{76EB036C-07A7-446B-91CB-CECCF6977DF3}" TcBaseType="true" HideType="true">UINTARR2_2</Name>
@@ -1329,19 +1329,19 @@ External Setpoint Generation:
 			<OtherSettings AllowMotionCmdToSlave="true"/>
 		</AxisPara>
 		<Encoder Name="Enc" EncType="29">
-			<EncPara ScaleFactorNumerator="5e-05" Offset="-214678.9304" MaxCount="#xffffffff" ReferenceSystem="1">
-				<SoftEndMinControl Enable="true" Range="-84.7752"/>
-				<SoftEndMaxControl Enable="true"/>
+			<EncPara ScaleFactorNumerator="5e-05" Offset="-214686.941" MaxCount="#xffffffff" ReferenceSystem="1">
+				<SoftEndMinControl Range="-92.82"/>
+				<SoftEndMaxControl Range="-8"/>
 				<Inc RefSoftSyncMask="#x0000ffff"/>
-				<ParameterChanged>25</ParameterChanged>
-				<ParameterChanged>7</ParameterChanged>
+				<ParameterChanged>14</ParameterChanged>
+				<ParameterChanged>13</ParameterChanged>
 			</EncPara>
 			<Vars VarGrpType="1">
 				<Name>Inputs</Name>
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{9ED17BA1-BC38-47CA-9DD2-F96861AB0266}" Namespace="MC">NCENCODERSTRUCT_IN3</Type>
-					<BitOffs>44928</BitOffs>
+					<BitOffs>51008</BitOffs>
 					<SubVar>
 						<Name>nState1</Name>
 						<Comment>
@@ -1371,7 +1371,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{4AA66E19-7B91-4A09-817D-0357681B7869}" Namespace="MC">NCENCODERSTRUCT_OUT3</Type>
-					<BitOffs>72576</BitOffs>
+					<BitOffs>78656</BitOffs>
 				</Var>
 			</Vars>
 		</Encoder>
@@ -1385,7 +1385,7 @@ External Setpoint Generation:
 				<Var>
 					<Name>In</Name>
 					<Type GUID="{F95C7C69-0C87-46C4-9559-1285CCA5B23A}" Namespace="MC">NCDRIVESTRUCT_IN2</Type>
-					<BitOffs>45568</BitOffs>
+					<BitOffs>51648</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataIn1</Name>
 					</SubVar>
@@ -1423,7 +1423,7 @@ Drive Status 4 (manually linked):
 				<Var>
 					<Name>Out</Name>
 					<Type GUID="{644DC4BD-3D15-4DCB-94C7-24F3A5D579AA}" Namespace="MC">NCDRIVESTRUCT_OUT2</Type>
-					<BitOffs>73216</BitOffs>
+					<BitOffs>79296</BitOffs>
 					<SubVar TypeFormatIndex="2">
 						<Name>nDataOut1</Name>
 					</SubVar>
@@ -1477,7 +1477,7 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>FromPlc</Name>
 				<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
-				<BitOffs>43904</BitOffs>
+				<BitOffs>49984</BitOffs>
 			</Var>
 		</Vars>
 		<Vars VarGrpType="2" InsertType="1">
@@ -1485,7 +1485,7 @@ Drive Status 4 (manually linked):
 			<Var>
 				<Name>ToPlc</Name>
 				<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-				<BitOffs>70528</BitOffs>
+				<BitOffs>76608</BitOffs>
 				<SubVar>
 					<Name>AxisState</Name>
 					<Comment>

--- a/plc-lfe-motion/lfe_motion/POUs/PRG_IM1L1_PPM.TcPOU
+++ b/plc-lfe-motion/lfe_motion/POUs/PRG_IM1L1_PPM.TcPOU
@@ -26,8 +26,8 @@ END_VAR
     stYStage := Main.M23,
     fPolished := -71.69,
     fFrosted := -97.70, // Actually a second polished yag
-    fPower := -38.06,
-    fOut := -11.1); // 0.94 in doc, but limit switch is closer]]></ST>
+    fPower := -47.59,
+    fOut := -8.59);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/plc-lfe-motion/lfe_motion/POUs/PRG_IM1L1_PPM.TcPOU
+++ b/plc-lfe-motion/lfe_motion/POUs/PRG_IM1L1_PPM.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="PRG_IM1L1_PPM" Id="{280e2bcd-0287-45b1-b768-ade5bf5e5119}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_IM1L1_PPM
 VAR
@@ -24,10 +24,10 @@ END_VAR
     <Implementation>
       <ST><![CDATA[fbIM1L1(
     stYStage := Main.M23,
-    fPolished := -50,
-    fFrosted := -60,
-    fPower := -70,
-    fOut := 0);]]></ST>
+    fPolished := -71.69,
+    fFrosted := -97.70, // Actually a second polished yag
+    fPower := -38.06,
+    fOut := -11.1); // 0.94 in doc, but limit switch is closer]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/plc-lfe-motion/lfe_motion/POUs/PRG_IM3L0_PPM.TcPOU
+++ b/plc-lfe-motion/lfe_motion/POUs/PRG_IM3L0_PPM.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="PRG_IM3L0_PPM" Id="{e4255619-3c3a-488b-9f38-90b77c8df5be}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRG_IM3L0_PPM
 VAR
@@ -24,10 +24,10 @@ END_VAR
     <Implementation>
       <ST><![CDATA[fbIM3L0(
     stYStage := Main.M27,
-    fPolished := -50,
-    fFrosted := -60,
-    fPower := -70,
-    fOut := 0);]]></ST>
+    fPolished := -71.50,
+    fFrosted := -97.51, // Actually a second polished yag
+    fPower := -37.87,
+    fOut := -8); // 1.13 in doc, but limit is closer]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/plc-lfe-motion/lfe_motion/POUs/PRG_IM3L0_PPM.TcPOU
+++ b/plc-lfe-motion/lfe_motion/POUs/PRG_IM3L0_PPM.TcPOU
@@ -26,8 +26,8 @@ END_VAR
     stYStage := Main.M27,
     fPolished := -71.50,
     fFrosted := -97.51, // Actually a second polished yag
-    fPower := -37.87,
-    fOut := -8); // 1.13 in doc, but limit is closer]]></ST>
+    fPower := -47.4,
+    fOut := -8.4);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
- Add the correct setpoints for the imager states
- Set soft limits to current switch positions
- add upgrade log to the gitignore. This file is created when you open an old project with a new twincat version

Not in a hurry to get this merged, just pushing so I don't forget about it. May need additional changes based on emails from David who is adamant that I should be able to reach the original set out position.